### PR TITLE
feat: Importar object em prop TObjectList

### DIFF
--- a/Source/GBJSON.Serializer.pas
+++ b/Source/GBJSON.Serializer.pas
@@ -217,7 +217,15 @@ begin
       LObjectItem := LListType.AsInstance.MetaclassType.Create;
       LObjectItem.InvokeMethod('create', []);
 
-      Self.JsonObjectToObject(LObjectItem, TJSONObject(AJsonArray.Items[I]));
+      if AJsonArray.Items[I] IS TJSONObject then
+      begin
+        Self.JsonObjectToObject(LObjectItem, TJSONObject(AJsonArray.Items[I]));
+      end
+      else
+      begin
+        Self.JsonObjectToObject(LObjectItem, TJSONObject(AJsonArray));
+      end;
+
       AProperty.GetValue(AObject).AsObject.InvokeMethod('Add', [LObjectItem]);
     end
     else


### PR DESCRIPTION
Alteramos a conversão do JSON para classe para caso a propriedade seja ObjectList (JSONArray) e o JSON ser enviado como JSONObject, a importação seja realizada.
Atualmente caso tenha este cenário é gerado erro.

Exemplo Classes (Pai com Array de filhos):
![image](https://github.com/gabrielbaltazar/GBJSON/assets/79713593/d522335a-7703-44ad-bb07-04acc10f8c76)
![image](https://github.com/gabrielbaltazar/GBJSON/assets/79713593/c545812b-6327-4cfd-9bd5-a3ea9fe0539f)

Exemplo chamada (Enviando filhos como Array e como Object) a resposta é o loop no nome dos filhos:
![image](https://github.com/gabrielbaltazar/GBJSON/assets/79713593/8ede36d2-1a50-41cc-9ef0-ec932330c637)
![image](https://github.com/gabrielbaltazar/GBJSON/assets/79713593/dba20e2c-87e8-43ed-90d8-a8a0188999ac)
