### PR TITLE
Formatação de datas na serialização e desserialização

### DIFF
--- a/Source/GBJSON.Base.pas
+++ b/Source/GBJSON.Base.pas
@@ -13,9 +13,10 @@ type
   TGBJSONBase = class(TInterfacedObject)
   protected
     FDateTimeFormat: String;
+    FDateTimeLocale: string;
   public
     constructor Create; virtual;
-
+    procedure DateTimeLocale(AValue: string);
     procedure DateTimeFormat(AValue: string);
   end;
 
@@ -31,6 +32,11 @@ end;
 procedure TGBJSONBase.DateTimeFormat(AValue: string);
 begin
   FDateTimeFormat := AValue;
+end;
+
+procedure TGBJSONBase.DateTimeLocale(AValue: string);
+begin
+  FDateTimeLocale := AValue;
 end;
 
 end.

--- a/Source/GBJSON.Config.pas
+++ b/Source/GBJSON.Config.pas
@@ -19,6 +19,7 @@ type
     FCaseDefinition: TCaseDefinition;
     FIgnoreEmptyValues: Boolean;
     FDateTimeFormat: string;
+    FDateTimeLocale: string;
     constructor CreatePrivate;
   public
     constructor Create;
@@ -29,6 +30,8 @@ type
     function CaseDefinition: TCaseDefinition; overload;
     function DateTimeFormat(AValue: string): TGBJSONConfig; overload;
     function DateTimeFormat: string; overload;
+    function DateTimeLocale(AValue: string): TGBJSONConfig; overload;
+    function DateTimeLocale: string; overload;
     function IgnoreEmptyValues(AValue: Boolean): TGBJSONConfig; overload;
     function IgnoreEmptyValues: Boolean; overload;
   end;
@@ -78,6 +81,16 @@ end;
 function TGBJSONConfig.DateTimeFormat: string;
 begin
   result := FDateTimeFormat;
+end;
+
+function TGBJSONConfig.DateTimeLocale: string;
+begin
+  Result := FDateTimeLocale;
+end;
+
+function TGBJSONConfig.DateTimeLocale(AValue: string): TGBJSONConfig;
+begin
+  FDateTimeLocale := AValue;
 end;
 
 function TGBJSONConfig.DateTimeFormat(AValue: string): TGBJSONConfig;

--- a/Source/GBJSON.Config.pas
+++ b/Source/GBJSON.Config.pas
@@ -18,7 +18,7 @@ type
 
     FCaseDefinition: TCaseDefinition;
     FIgnoreEmptyValues: Boolean;
-
+    FDateTimeFormat: string;
     constructor CreatePrivate;
   public
     constructor Create;
@@ -27,7 +27,8 @@ type
 
     function CaseDefinition(AValue: TCaseDefinition): TGBJSONConfig; overload;
     function CaseDefinition: TCaseDefinition; overload;
-
+    function DateTimeFormat(AValue: string): TGBJSONConfig; overload;
+    function DateTimeFormat: string; overload;
     function IgnoreEmptyValues(AValue: Boolean): TGBJSONConfig; overload;
     function IgnoreEmptyValues: Boolean; overload;
   end;
@@ -72,6 +73,16 @@ end;
 function TGBJSONConfig.IgnoreEmptyValues: Boolean;
 begin
   Result := FIgnoreEmptyValues;
+end;
+
+function TGBJSONConfig.DateTimeFormat: string;
+begin
+  result := FDateTimeFormat;
+end;
+
+function TGBJSONConfig.DateTimeFormat(AValue: string): TGBJSONConfig;
+begin
+  FDateTimeFormat := AValue;
 end;
 
 function TGBJSONConfig.IgnoreEmptyValues(AValue: Boolean): TGBJSONConfig;

--- a/Source/GBJSON.DateTime.Helper.pas
+++ b/Source/GBJSON.DateTime.Helper.pas
@@ -14,10 +14,19 @@ type
   TGBJSONDatetimeHelper = record helper for TDateTime
   private
     function Iso8601ToDateTime(AValue: string): TDateTime;
+//    function NormalizeMask(const S: string): string;
+//    function DetectTimeSeparator(const S: string): Char;
+//    function DetectDateSeparator(const S: string): Char;
+//    function SplitDateAndTime(const AMask: string; out ADatePart, ATimePart: string): Boolean;
+    function BuildFormatSettingsFromMask(
+      const AMask: string;
+      const ALocale: string = 'en-US'
+    ): TFormatSettings;
   public
     function DateTimeToIso8601: string;
     function Format(ADateFormat: string): string;
     function FormatYYYY_MM_DD: string;
+    procedure FromCustomFormatToDateTime(AValue, AformatDateTime,ALocale: string);
     procedure FromIso8601ToDateTime(AValue: string);
   end;
 
@@ -47,6 +56,17 @@ end;
 function TGBJSONDatetimeHelper.FormatYYYY_MM_DD: string;
 begin
   Result := Format('yyyy-MM-dd');
+end;
+
+procedure TGBJSONDatetimeHelper.FromCustomFormatToDateTime(AValue, AformatDateTime, ALocale: string);
+var
+  formatSettings: TFormatSettings;
+begin
+  if ALocale.Trim.IsEmpty then
+    formatSettings := BuildFormatSettingsFromMask(AformatDateTime)
+  else
+    formatSettings :=BuildFormatSettingsFromMask(AformatDateTime,ALocale);
+  self := StrToDate(AValue,formatSettings);
 end;
 
 procedure TGBJSONDatetimeHelper.fromIso8601ToDateTime(AValue: string);
@@ -103,5 +123,111 @@ begin
   end;
 end;
 
+function DetectDateSeparator(const S: string): Char;
+var
+  C: Char;
+begin
+  for C in S do
+    if CharInSet(C, ['/', '-', '.']) then
+      Exit(C);
+  Result := '/';
+end;
+
+function DetectTimeSeparator(const S: string): Char;
+var
+  C: Char;
+begin
+  for C in S do
+    if CharInSet(C, [':', '.']) then
+      Exit(C);
+  Result := ':';
+end;
+
+function NormalizeMask(const S: string): string;
+begin
+  Result := Trim(S);
+  Result := StringReplace(Result, 'HH', 'hh', [rfReplaceAll]);
+  Result := StringReplace(Result, 'H', 'h', [rfReplaceAll]);
+  Result := StringReplace(Result, 'NN', 'nn', [rfReplaceAll]);
+  Result := StringReplace(Result, 'N', 'n', [rfReplaceAll]);
+  Result := StringReplace(Result, 'SS', 'ss', [rfReplaceAll]);
+  Result := StringReplace(Result, 'S', 's', [rfReplaceAll]);
+  Result := StringReplace(Result, 'YYYY', 'yyyy', [rfReplaceAll]);
+  Result := StringReplace(Result, 'YYY', 'yyy', [rfReplaceAll]);
+  Result := StringReplace(Result, 'YY', 'yy', [rfReplaceAll]);
+  Result := StringReplace(Result, 'DD', 'dd', [rfReplaceAll]);
+  Result := StringReplace(Result, 'D', 'd', [rfReplaceAll]);
+  Result := StringReplace(Result, 'MM', 'mm', [rfReplaceAll]);
+end;
+
+function SplitDateAndTime(const AMask: string; out ADatePart, ATimePart: string): Boolean;
+var
+  P: Integer;
+  S: string;
+begin
+  S := Trim(AMask);
+  P := Pos(' ', S);
+
+  if P > 0 then
+  begin
+    ADatePart := Trim(Copy(S, 1, P - 1));
+    ATimePart := Trim(Copy(S, P + 1, MaxInt));
+  end
+  else
+  begin
+    if (Pos(':', S) > 0) or (Pos('h', LowerCase(S)) > 0) or (Pos('n', LowerCase(S)) > 0) then
+    begin
+      ADatePart := '';
+      ATimePart := S;
+    end
+    else
+    begin
+      ADatePart := S;
+      ATimePart := '';
+    end;
+  end;
+
+  Result := (ADatePart <> '') or (ATimePart <> '');
+end;
+
+function TGBJSONDatetimeHelper.BuildFormatSettingsFromMask(
+  const AMask: string;
+  const ALocale: string
+): TFormatSettings;
+var
+  Mask: string;
+  DatePart: string;
+  TimePart: string;
+  LowerTime: string;
+begin
+  Result := TFormatSettings.Create(ALocale);
+  Mask := NormalizeMask(AMask);
+
+  if not SplitDateAndTime(Mask, DatePart, TimePart) then
+    Exit;
+
+  if DatePart <> '' then
+  begin
+    Result.DateSeparator := DetectDateSeparator(DatePart);
+    Result.ShortDateFormat := DatePart;
+    Result.LongDateFormat := DatePart;
+  end;
+
+  if TimePart <> '' then
+  begin
+    Result.TimeSeparator := DetectTimeSeparator(TimePart);
+    Result.ShortTimeFormat := TimePart;
+    Result.LongTimeFormat := TimePart;
+
+    LowerTime := LowerCase(TimePart);
+    if (Pos('am/pm', LowerTime) > 0) or (Pos('a/p', LowerTime) > 0) then
+    begin
+      Result.TimeAMString := 'AM';
+      Result.TimePMString := 'PM';
+    end;
+  end;
+end;
+
 end.
+
 

--- a/Source/GBJSON.DateTime.Helper.pas
+++ b/Source/GBJSON.DateTime.Helper.pas
@@ -14,10 +14,6 @@ type
   TGBJSONDatetimeHelper = record helper for TDateTime
   private
     function Iso8601ToDateTime(AValue: string): TDateTime;
-//    function NormalizeMask(const S: string): string;
-//    function DetectTimeSeparator(const S: string): Char;
-//    function DetectDateSeparator(const S: string): Char;
-//    function SplitDateAndTime(const AMask: string; out ADatePart, ATimePart: string): Boolean;
     function BuildFormatSettingsFromMask(
       const AMask: string;
       const ALocale: string = 'en-US'
@@ -66,7 +62,7 @@ begin
     formatSettings := BuildFormatSettingsFromMask(AformatDateTime)
   else
     formatSettings :=BuildFormatSettingsFromMask(AformatDateTime,ALocale);
-  self := StrToDate(AValue,formatSettings);
+  self := StrToDateTime(AValue,formatSettings);
 end;
 
 procedure TGBJSONDatetimeHelper.fromIso8601ToDateTime(AValue: string);

--- a/Source/GBJSON.Deserializer.pas
+++ b/Source/GBJSON.Deserializer.pas
@@ -52,6 +52,8 @@ uses
 constructor TGBJSONDeserializer<T>.Create(AUseIgnore: Boolean = True);
 begin
   inherited Create;
+  if not TGBJSONConfig.GetInstance.DateTimeFormat.Trim.IsEmpty then
+    DateTimeFormat(TGBJSONConfig.GetInstance.DateTimeFormat.Trim);
   FUseIgnore := AUseIgnore;
 end;
 

--- a/Source/GBJSON.Serializer.pas
+++ b/Source/GBJSON.Serializer.pas
@@ -55,6 +55,10 @@ constructor TGBJSONSerializer<T>.Create(AUseIgnore: Boolean);
 begin
   inherited Create;
   FUseIgnore := AUseIgnore;
+  if not TGBJSONConfig.GetInstance.DateTimeFormat.Trim.IsEmpty then
+    DateTimeFormat(TGBJSONConfig.GetInstance.DateTimeFormat.Trim);
+  if not TGBJSONConfig.GetInstance.DateTimeLocale.Trim.IsEmpty then
+    DateTimeLocale(TGBJSONConfig.GetInstance.DateTimeLocale.Trim);
 end;
 
 function TGBJSONSerializer<T>.JsonArrayToList(AValue: TJSONArray): TObjectList<T>;
@@ -283,7 +287,9 @@ var
   LJSONDate: TJSONValue;
   LDate: TDateTime;
 begin
-  if AJSONValue.TryGetValue<TJSONValue>('$date', LJSONDate) then
+  if not FDateTimeFormat.Trim.IsEmpty then
+    LDate.FromCustomFormatToDateTime(AJSONValue.Value,FDateTimeFormat.Trim ,FDateTimeLocale.Trim)
+  else if AJSONValue.TryGetValue<TJSONValue>('$date', LJSONDate) then
     LDate.FromIso8601ToDateTime(LJSONDate.Value)
   else
     LDate.FromIso8601ToDateTime(AJSONValue.Value);


### PR DESCRIPTION
adicionado suporte a definição de dateformat para as datas que serão serializadas e desserializadas.

1- Foi corrigido o uso do dateformat já existente na serialização e desserialização.
2- Foi adicionado o a propriedade DateTimeLocale para informar o formato local. O valor padrão é "en-US".
